### PR TITLE
Fix Typo in InCluster Job Example

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -19,7 +19,7 @@ spec:
         container.apparmor.security.beta.kubernetes.io/kubeaudit: runtime/default
         seccomp.security.alpha.kubernetes.io/pod: runtime/default
     spec:
-      automountServiceAccount: false
+      automountServiceAccountToken: false
       restartPolicy: OnFailure
       containers:
         - name: kubeaudit


### PR DESCRIPTION
##### Description

Found a small typo in the in-cluster job example.
Should be `automountServiceAccountToken` not `automountServiceAccount`.

```
pbpaste | kubectl apply -f -
error: error validating "STDIN": error validating data: ValidationError(Job.spec.template.spec): unknown field "automountServiceAccount" in io.k8s.api.core.v1.PodSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

Also I think it would be best to set this to `true`, as kubeaudit actually needs the token and the rest of the CA mounted alongside it to communicate with the API Server. It'll fail otherwise even in clusters without RBAC enabled (at least in Docker Desktops for Mac's Kubernetes cluster), see logs below:

```
time="2020-10-12T10:07:28Z" level=fatal msg="Error auditing cluster in local mode" error="invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"
```

##### Type of change

- [x] Documentation fix 📚

##### How Has This Been Tested?

- [ ] Run locally on Docker Desktop Kubernetes Cluster

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage did not decrease
- [x] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
